### PR TITLE
Support for legacy type hinting

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import argparse
 from pathlib import Path
 import shutil
 import subprocess
+from typing import Dict, List
 
 from uvm_code_gen import *
 
@@ -24,7 +25,7 @@ args = parser.parse_args()
 
 
 # VIP
-vips: list[UvmVip] = []
+vips: List[UvmVip] = []
 for f in args.vip_config:
     vip = UvmVip(description_file=f, output_dir=f"{OUTPUT_DIR}/vip")
     if not args.no_vip:
@@ -33,7 +34,7 @@ for f in args.vip_config:
 
 
 # VIP -> instances map
-vip_instances: dict[str, list[str]] = {}
+vip_instances: Dict[str, List[str]] = {}
 if not args.top_map:
     # default map
     for v in vips:

--- a/uvm_code_gen/top.py
+++ b/uvm_code_gen/top.py
@@ -1,13 +1,14 @@
+from typing import List, Dict
+
 from .utils import *
 from .vip import UvmVip
-
 
 class UvmTop(object):
     """parse template and create UVM verification top-level environment"""
 
     def __init__(self,
-                 vips: list[UvmVip],
-                 vip_instances: dict[str, list[str]],
+                 vips: List[UvmVip],
+                 vip_instances: Dict[str, List[str]],
                  top_name: str = "top",
                  output_dir: str = "./output",
                  template_dir: str = ""):

--- a/uvm_code_gen/utils.py
+++ b/uvm_code_gen/utils.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import re
+from typing import Dict
 
 
 class Template:
@@ -27,7 +28,7 @@ class StrLists:
     def __init__(self):
         self. sl = {}
 
-    def append(self, fmt_values: dict[str, str]):
+    def append(self, fmt_values: Dict[str, str]):
         for name in fmt_values:
             self.sl.setdefault(name, [])
             string = fmt_values[name][:-1]  # remove last "\n"
@@ -56,7 +57,7 @@ def get_template_dir(template_dir=""):
     return Path(template_dir)
 
 
-def format_template_dir(template_dir_path: Path, force_empty_string= False, **fmt_values) -> dict[str, str]:
+def format_template_dir(template_dir_path: Path, force_empty_string= False, **fmt_values) -> Dict[str, str]:
     d = {}
     for template_path in template_dir_path.glob('*'):
         if template_path.is_dir():


### PR DESCRIPTION
Current main will not run on `python <3.8` due to the type hinting:
https://stackoverflow.com/questions/63460126/typeerror-type-object-is-not-subscriptable-in-a-function-signature

More technical read there:
https://stackoverflow.com/questions/39458193/using-list-tuple-etc-from-typing-vs-directly-referring-type-as-list-tuple-etc

This pull request aim at solving this issue but both `Dict` and `List` are marked as deprecated since 3.9
https://docs.python.org/3/library/typing.html